### PR TITLE
capture_record URLs should be relative

### DIFF
--- a/sketchy/controllers/tasks.py
+++ b/sketchy/controllers/tasks.py
@@ -123,9 +123,9 @@ def do_capture(status_code, capture_record, hostname="", ssl=False):
     parsed_text.write(output)
    
     # Update the sketch record with the local URLs for the sketch, scrape, and html captures
-    capture_record.sketch_url = 'http://' + hostname + '/files/' + capture_name + '.png' if ssl == False else 'https://' + hostname + '/files/' + capture_name + '.png'
-    capture_record.scrape_url = 'http://' + hostname + '/files/' + capture_name + '.txt' if ssl == False else 'https://' + hostname + '/files/' + capture_name + '.txt'
-    capture_record.html_url = 'http://' + hostname + '/files/' + capture_name + '.html' if ssl == False else 'https://' + hostname + '/files/' + capture_name + '.html'
+    capture_record.sketch_url = '/files/' + capture_name + '.png'
+    capture_record.scrape_url = '/files/' + capture_name + '.txt'
+    capture_record.html_url = '/files/' + capture_name + '.html'
 
     # Create a dict that contains what files may need to be written to S3
     files_to_write = defaultdict(list)


### PR DESCRIPTION
sketch_url, scrape_url, and html_url should use relative URLs.  This simplifies the code and makes it more docker friendly.  (The API docker does not know the IP for the Nginx docker, making full URL's much more difficult.)
