### PR TITLE
USE_S3 fix for 'False' == True

### DIFF
--- a/config-default.py
+++ b/config-default.py
@@ -44,7 +44,7 @@ PHANTOMJS = '/usr/local/bin/phantomjs'
 
 # S3 Specific configurations
 # This will store your sketches, scrapes, and html in an S3 bucket
-USE_S3 = os.getenv('use_s3', 'False')
+USE_S3 = os.getenv('use_s3', 'False').lower() == 'true'
 S3_BUCKET_PREFIX = os.getenv('bucket_prefix', '')
 S3_LINK_EXPIRATION = 6000000
 


### PR DESCRIPTION
os.getenv() returns a string 'False' by default, so in tasks.py when
app.config['USE_S3'] was used, it would always return True no matter
what
