### PR TITLE
Cleanup setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 from setuptools import setup
-import multiprocessing
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,17 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
+import os
 from setuptools import setup
 
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
     name='sketchy',
     version='1.1',
-    long_description=__doc__,
+    long_description=read('README.md'),
     packages=['sketchy'],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Removed an unused import from setup.py and made the long_description contain the contents of README.md.