### PR TITLE
Update filename in S3

### DIFF
--- a/sketchy/controllers/tasks.py
+++ b/sketchy/controllers/tasks.py
@@ -179,7 +179,7 @@ def s3_save(files_to_write, the_record):
             calling_format = boto.s3.connection.OrdinaryCallingFormat()
         )
         key = Key(conn.get_bucket(app.config.get('S3_BUCKET_PREFIX')))
-        path = "sketchy/{}/{}".format(capture_type, the_record.id)
+        path = "sketchy/{}/{}".format(capture_type, file_name)
         key.key = path
         key.set_contents_from_filename(app.config['LOCAL_STORAGE_FOLDER'] + '/' + file_name)
 


### PR DESCRIPTION
The capture id as the file name has no file extension. And will not be recognized by Amazon S3.
This can be prevented by using file name instead.
![screenshot from 2015-08-20 14 21 11](https://cloud.githubusercontent.com/assets/1774060/9383118/c1975eec-4746-11e5-8099-9e2d6d5c4bdf.png)
